### PR TITLE
external/swizzle: fix out-of-bounds ARM64 BGRA conversion

### DIFF
--- a/external/swizzle/swizzle_arm64.go
+++ b/external/swizzle/swizzle_arm64.go
@@ -6,7 +6,11 @@
 
 package swizzle
 
-const useBGRA32 = true
+// bgra32's arm64 assembly routine does not consult the slice length and uses
+// hard-coded offsets. It can therefore read and write beyond a cursor image
+// buffer. Use BGRA's bounds-safe Go implementation until the assembly
+// implementation is corrected.
+const useBGRA32 = false
 const useBGRA16 = false
 const useBGRA4 = false
 

--- a/external/swizzle/swizzle_test.go
+++ b/external/swizzle/swizzle_test.go
@@ -1,0 +1,38 @@
+package swizzle
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestBGRAConvertsBuffersOfAnyPixelLength(t *testing.T) {
+	for _, pixelCount := range []int{0, 1, 8, 256, 576} {
+		t.Run(fmt.Sprintf("%d_pixels", pixelCount), func(t *testing.T) {
+			buf := make([]byte, pixelCount*4)
+			for i := 0; i < len(buf); i += 4 {
+				buf[i+0] = byte(i / 4)
+				buf[i+1] = 0x11
+				buf[i+2] = 0x22
+				buf[i+3] = 0x33
+			}
+			want := append([]byte(nil), buf...)
+			for i := 0; i < len(want); i += 4 {
+				want[i], want[i+2] = want[i+2], want[i]
+			}
+
+			if err := BGRA(buf); err != nil {
+				t.Fatalf("BGRA returned an error: %v", err)
+			}
+			if !bytes.Equal(buf, want) {
+				t.Fatal("BGRA produced incorrect pixel order")
+			}
+		})
+	}
+}
+
+func TestBGRARejectsPartialPixel(t *testing.T) {
+	if err := BGRA(make([]byte, 3)); err != ErrSliceNot32Bit {
+		t.Fatalf("BGRA error = %v, want %v", err, ErrSliceNot32Bit)
+	}
+}


### PR DESCRIPTION
## Problem

On Linux/ARM64, creating a Wayland display can crash while an Xcursor image is being decoded:

```text
swizzle.bgra32
swizzle.BGRA
wlcursor/xcursor.parseImg
window.DisplayCreate
```

`BGRA` passes a variable-length slice to the ARM64 `bgra32` routine, but that assembly routine does not consult the slice length and instead iterates between hard-coded offsets. Its memory accesses therefore do not stay within the supplied image buffer. A 24×24 cursor image (2,304 bytes) reliably exposed this as an invalid memory access before the Wayland window could be created.

## Fix

Disable the unsafe ARM64 `bgra32` path so `BGRA` uses its existing bounds-safe Go loop. This follows the same conservative approach used by current `golang.org/x/exp/shiny`, where non-AMD64 platforms use the Go implementation.

The behavior and API are unchanged: red and blue bytes are swapped for every complete pixel, while green and alpha remain untouched. The tradeoff is a small amount of scalar work while loading images instead of memory-unsafe assembly.

## Tests

Added regression coverage for:

- empty input;
- one pixel;
- buffers aligned to the old 32-byte chunk size;
- larger buffers;
- a 24×24 cursor-sized buffer;
- rejection of a partial pixel.

Validated on Linux/ARM64 with:

```text
go test -race ./external/swizzle
go vet ./external/swizzle
GOOS=linux GOARCH=amd64 go test -c ./external/swizzle
```

The patched module was also used to build and run F4 with `--gui=wayland`; the application initialized the native Wayland backend and remained running without a crash.
