### PR TITLE
Forward modern Wayland pointer frames and wheel values

### DIFF
--- a/window/window_linux.go
+++ b/window/window_linux.go
@@ -721,6 +721,14 @@ type WidgetHandler interface {
 	PointerFrame(Widget *Widget, Input *Input)
 }
 
+// AxisValue120Handler optionally receives high-resolution wheel values from
+// wl_pointer version 8 and newer. Widget handlers that only implement
+// WidgetHandler continue to receive accumulated whole steps through
+// AxisDiscrete.
+type AxisValue120Handler interface {
+	AxisValue120(Widget *Widget, Input *Input, axis uint32, value120 int32)
+}
+
 type Input struct {
 	Display            *Display
 	seat               *wl.Seat
@@ -739,13 +747,14 @@ type Input struct {
 	cursorDelayFd      int32 //nolint:unused // Reserved for future use
 	cursorTimerRunning bool  //nolint:unused // Reserved for future use
 	//cursor_task          task
-	pointerSurface     *wl.Surface
-	modifiers          ModType
-	pointerEnterSerial uint32
-	cursorSerial       uint32
-	sx                 float32
-	sy                 float32
-	currentPtrSurface  *wl.Surface // Track which surface pointer is currently on
+	pointerSurface        *wl.Surface
+	modifiers             ModType
+	pointerEnterSerial    uint32
+	cursorSerial          uint32
+	sx                    float32
+	sy                    float32
+	currentPtrSurface     *wl.Surface // Track which surface pointer is currently on
+	axisValue120Remainder [2]int32
 
 	focusWidget *Widget
 	grab        *Widget
@@ -1234,9 +1243,28 @@ func (input *Input) PointerButton(
 }
 
 func (input *Input) HandlePointerFrame(ev wl.PointerFrameEvent) {
+	input.PointerFrame(nil)
 }
 
 func (input *Input) PointerFrame(wlPointer *wl.Pointer) {
+	var Window = input.pointerFocus
+	if Window == nil {
+		return
+	}
+	var Widget *Widget
+	if input.grab != nil {
+		Widget = input.grab
+	} else {
+		Widget = input.focusWidget
+	}
+	if Widget == nil {
+		return
+	}
+	if Widget.userdata != nil {
+		Widget.userdata.PointerFrame(Widget, input)
+	} else if Window.Userdata != nil {
+		Window.Userdata.PointerFrame(Widget, input)
+	}
 }
 
 func (input *Input) HandlePointerAxis(ev wl.PointerAxisEvent) {
@@ -1339,6 +1367,48 @@ func (input *Input) PointerAxisDiscrete(wlPointer *wl.Pointer, axis uint32, disc
 		Widget.userdata.AxisDiscrete(Widget, input, axis, discrete)
 	} else if Window.Userdata != nil {
 		Window.Userdata.AxisDiscrete(Widget, input, axis, discrete)
+	}
+}
+
+func (input *Input) HandlePointerAxisValue120(ev wl.PointerAxisValue120Event) {
+	input.PointerAxisValue120(nil, ev.Axis, ev.Value120)
+}
+
+func (input *Input) PointerAxisValue120(wlPointer *wl.Pointer, axis uint32, value120 int32) {
+	var Window = input.pointerFocus
+	if Window == nil {
+		return
+	}
+	var Widget *Widget
+	if input.grab != nil {
+		Widget = input.grab
+	} else {
+		Widget = input.focusWidget
+	}
+	if Widget == nil {
+		return
+	}
+
+	if Widget.userdata != nil {
+		if handler, ok := Widget.userdata.(AxisValue120Handler); ok {
+			handler.AxisValue120(Widget, input, axis, value120)
+			return
+		}
+	} else if Window.Userdata != nil {
+		if handler, ok := Window.Userdata.(AxisValue120Handler); ok {
+			handler.AxisValue120(Widget, input, axis, value120)
+			return
+		}
+	}
+
+	if axis >= uint32(len(input.axisValue120Remainder)) {
+		return
+	}
+	input.axisValue120Remainder[axis] += value120
+	steps := input.axisValue120Remainder[axis] / 120
+	input.axisValue120Remainder[axis] -= steps * 120
+	if steps != 0 {
+		input.PointerAxisDiscrete(wlPointer, axis, steps)
 	}
 }
 

--- a/window/window_linux.go
+++ b/window/window_linux.go
@@ -755,6 +755,7 @@ type Input struct {
 	sy                    float32
 	currentPtrSurface     *wl.Surface // Track which surface pointer is currently on
 	axisValue120Remainder [2]int32
+	axisValue120Seen      [2]bool
 
 	focusWidget *Widget
 	grab        *Widget
@@ -1247,6 +1248,12 @@ func (input *Input) HandlePointerFrame(ev wl.PointerFrameEvent) {
 }
 
 func (input *Input) PointerFrame(wlPointer *wl.Pointer) {
+	defer func() {
+		for axis := range input.axisValue120Seen {
+			input.axisValue120Seen[axis] = false
+		}
+	}()
+
 	var Window = input.pointerFocus
 	if Window == nil {
 		return
@@ -1272,6 +1279,12 @@ func (input *Input) HandlePointerAxis(ev wl.PointerAxisEvent) {
 }
 
 func (input *Input) PointerAxis(wlPointer *wl.Pointer, time uint32, axis uint32, value float32) {
+	// axis_value120 is always paired with one raw axis event of the same
+	// axis later in the frame. Consumers that scroll in discrete steps must
+	// process one representation, not both.
+	if axis < uint32(len(input.axisValue120Seen)) && input.axisValue120Seen[axis] {
+		return
+	}
 	var Window = input.pointerFocus
 	if Window == nil {
 		return
@@ -1388,6 +1401,10 @@ func (input *Input) PointerAxisValue120(wlPointer *wl.Pointer, axis uint32, valu
 	if Widget == nil {
 		return
 	}
+	if axis >= uint32(len(input.axisValue120Remainder)) {
+		return
+	}
+	input.axisValue120Seen[axis] = true
 
 	if Widget.userdata != nil {
 		if handler, ok := Widget.userdata.(AxisValue120Handler); ok {
@@ -1401,9 +1418,6 @@ func (input *Input) PointerAxisValue120(wlPointer *wl.Pointer, axis uint32, valu
 		}
 	}
 
-	if axis >= uint32(len(input.axisValue120Remainder)) {
-		return
-	}
 	input.axisValue120Remainder[axis] += value120
 	steps := input.axisValue120Remainder[axis] / 120
 	input.axisValue120Remainder[axis] -= steps * 120

--- a/window/window_linux_test.go
+++ b/window/window_linux_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/neurlang/wayland/wl"
 )
 
 // noopRunner is a no-op implementation of the runner interface for testing.
@@ -99,6 +101,72 @@ func TestDisplayRunWakesOnDefer(t *testing.T) {
 		default:
 			// Not done yet; yield briefly before polling again.
 			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}
+
+type pointerFrameHandler struct {
+	WidgetHandler
+	frames    int
+	value120s []int32
+}
+
+func (h *pointerFrameHandler) PointerFrame(*Widget, *Input) {
+	h.frames++
+}
+
+func (h *pointerFrameHandler) AxisValue120(_ *Widget, _ *Input, _ uint32, value120 int32) {
+	h.value120s = append(h.value120s, value120)
+}
+
+type discreteAxisHandler struct {
+	WidgetHandler
+	steps []int32
+}
+
+func (h *discreteAxisHandler) AxisDiscrete(_ *Widget, _ *Input, _ uint32, discrete int32) {
+	h.steps = append(h.steps, discrete)
+}
+
+func pointerTestInput(handler WidgetHandler) *Input {
+	display := &Display{}
+	window := &Window{Display: display}
+	widget := &Widget{Window: window, userdata: handler}
+	window.mainSurface = &surface{Window: window, Widget: widget}
+	return &Input{Display: display, pointerFocus: window, focusWidget: widget}
+}
+
+func TestPointerFrameAndValue120ReachOptionalWidgetHandler(t *testing.T) {
+	handler := &pointerFrameHandler{}
+	input := pointerTestInput(handler)
+
+	input.PointerAxisValue120(nil, wl.PointerAxisVerticalScroll, 30)
+	input.PointerFrame(nil)
+
+	if len(handler.value120s) != 1 || handler.value120s[0] != 30 {
+		t.Fatalf("value120 events = %v, want [30]", handler.value120s)
+	}
+	if handler.frames != 1 {
+		t.Fatalf("pointer frames = %d, want 1", handler.frames)
+	}
+}
+
+func TestPointerValue120FallbackAccumulatesWholeSteps(t *testing.T) {
+	handler := &discreteAxisHandler{}
+	input := pointerTestInput(handler)
+
+	for range 4 {
+		input.PointerAxisValue120(nil, wl.PointerAxisVerticalScroll, 30)
+	}
+	input.PointerAxisValue120(nil, wl.PointerAxisVerticalScroll, -240)
+
+	want := []int32{1, -2}
+	if len(handler.steps) != len(want) {
+		t.Fatalf("discrete events = %v, want %v", handler.steps, want)
+	}
+	for i := range want {
+		if handler.steps[i] != want[i] {
+			t.Fatalf("discrete events = %v, want %v", handler.steps, want)
 		}
 	}
 }

--- a/window/window_linux_test.go
+++ b/window/window_linux_test.go
@@ -121,12 +121,19 @@ func (h *pointerFrameHandler) AxisValue120(_ *Widget, _ *Input, _ uint32, value1
 
 type discreteAxisHandler struct {
 	WidgetHandler
-	steps []int32
+	steps   []int32
+	rawAxes int
 }
 
 func (h *discreteAxisHandler) AxisDiscrete(_ *Widget, _ *Input, _ uint32, discrete int32) {
 	h.steps = append(h.steps, discrete)
 }
+
+func (h *discreteAxisHandler) Axis(_ *Widget, _ *Input, _ uint32, _ uint32, _ float32) {
+	h.rawAxes++
+}
+
+func (h *discreteAxisHandler) PointerFrame(*Widget, *Input) {}
 
 func pointerTestInput(handler WidgetHandler) *Input {
 	display := &Display{}
@@ -157,8 +164,12 @@ func TestPointerValue120FallbackAccumulatesWholeSteps(t *testing.T) {
 
 	for range 4 {
 		input.PointerAxisValue120(nil, wl.PointerAxisVerticalScroll, 30)
+		input.PointerAxis(nil, 0, wl.PointerAxisVerticalScroll, 5)
+		input.PointerFrame(nil)
 	}
 	input.PointerAxisValue120(nil, wl.PointerAxisVerticalScroll, -240)
+	input.PointerAxis(nil, 0, wl.PointerAxisVerticalScroll, -10)
+	input.PointerFrame(nil)
 
 	want := []int32{1, -2}
 	if len(handler.steps) != len(want) {
@@ -168,5 +179,13 @@ func TestPointerValue120FallbackAccumulatesWholeSteps(t *testing.T) {
 		if handler.steps[i] != want[i] {
 			t.Fatalf("discrete events = %v, want %v", handler.steps, want)
 		}
+	}
+	if handler.rawAxes != 0 {
+		t.Fatalf("paired raw axis was delivered %d times, want 0", handler.rawAxes)
+	}
+
+	input.PointerAxis(nil, 0, wl.PointerAxisVerticalScroll, 5)
+	if handler.rawAxes != 1 {
+		t.Fatalf("raw axis after frame was delivered %d times, want 1", handler.rawAxes)
 	}
 }

--- a/wlclient/wlclient.go
+++ b/wlclient/wlclient.go
@@ -26,6 +26,7 @@ type PointerListener interface {
 	wl.PointerAxisSourceHandler
 	wl.PointerAxisStopHandler
 	wl.PointerAxisDiscreteHandler
+	wl.PointerAxisValue120Handler
 }
 
 func PointerAddListener(p *wl.Pointer, h PointerListener) {
@@ -38,6 +39,7 @@ func PointerAddListener(p *wl.Pointer, h PointerListener) {
 	p.AddAxisSourceHandler(h)
 	p.AddAxisStopHandler(h)
 	p.AddAxisDiscreteHandler(h)
+	p.AddAxisValue120Handler(h)
 
 }
 func PointerDestroy(p *wl.Pointer) {


### PR DESCRIPTION
## Problem

The pointer listener stops at the deprecated `wl_pointer.axis_discrete` event. KDE exposes a modern wl_pointer version and sends `axis_value120` for wheel detents together with the coupled raw `axis` event, so clients never receive the discrete wheel information.

`Input.HandlePointerFrame` is also empty. Widgets therefore cannot accumulate the axis/source/value events belonging to one logical Wayland frame. This makes correct deduplication and smooth-axis fallback impossible.

## Fix

- Register the wl_pointer `axis_value120` listener.
- Add an optional `AxisValue120Handler` without changing the existing mandatory `WidgetHandler` interface.
- Forward `PointerFrame` to the focused or grabbed widget.
- For existing widget handlers, accumulate high-resolution values to whole 120-unit wheel steps and deliver them through `AxisDiscrete`.
- Suppress the one raw `axis` event coupled to `axis_value120` within the same frame, then clear that state at frame end. This prevents double scrolling while preserving raw axes from touchpads and continuous devices.
- Preserve pointer grabs when routing frames and wheel data.

The corresponding VTUI mouse-state and frame accumulator is in https://github.com/unxed/vtui/pull/49.

## Validation

- `go test -race -count=1 ./window/...`
- `go vet ./window ./wlclient`
- Regression coverage verifies optional value120 delivery, whole-step compatibility accumulation, frame forwarding, paired raw-axis suppression, and reset at the next frame.
- Built and live-tested through VTUI/F4 on KDE Wayland.