### PR TITLE
fix(window/linux): atomically schedule redraw tasks

### DIFF
--- a/window/window_linux.go
+++ b/window/window_linux.go
@@ -39,6 +39,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	xkb "github.com/neurlang/wayland/xkbcommon"
 )
@@ -3164,7 +3165,7 @@ func (parent *Widget) ScheduleResize(width int32, height int32) {
 //line 4269
 func (Window *Window) InhibitRedraw() {
 	Window.redrawInhibited = 1
-	Window.redrawTaskScheduled = 0
+	atomic.StoreInt32(&Window.redrawTaskScheduled, 0)
 }
 
 func (Window *Window) UninhibitRedraw() {
@@ -3297,7 +3298,7 @@ func surfaceRedraw(surface *surface) int {
 // line 4617
 func (Window *Window) Run(events uint32) {
 
-	Window.redrawTaskScheduled = 0
+	atomic.StoreInt32(&Window.redrawTaskScheduled, 0)
 
 	if Window.resizeNeeded != 0 {
 		if nil != Window.mainSurface.frameCb {
@@ -3322,11 +3323,12 @@ func windowScheduleRedrawTask(Window *Window) {
 		return
 	}
 
-	if Window.redrawTaskScheduled == 0 {
-
+	// Claim the task before publishing it to the display queue. Publishing
+	// first lets DisplayRun consume the task and clear this flag before this
+	// goroutine stores 1, leaving an empty queue with a permanently stale flag.
+	if atomic.CompareAndSwapInt32(&Window.redrawTaskScheduled, 0, 1) {
 		Window.redrawRunner = Window
 		displayDefer(Window.Display /*&Window.redraw_task,*/, Window)
-		Window.redrawTaskScheduled = 1
 	}
 }
 
@@ -3715,7 +3717,7 @@ func (d *Display) CreateDataSource() (*DataSource, error) {
 
 //line 6478
 func displayDefer(Display *Display /*task *task,*/, fun runner) {
-	Display.deferredMu.Lock() 
+	Display.deferredMu.Lock()
 	Display.deferredListNew = append(Display.deferredListNew, fun)
 	Display.deferredMu.Unlock()
 }

--- a/window/window_linux_test.go
+++ b/window/window_linux_test.go
@@ -4,6 +4,7 @@ package window
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -99,6 +100,47 @@ func TestDisplayRunWakesOnDefer(t *testing.T) {
 		default:
 			// Not done yet; yield briefly before polling again.
 			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}
+
+// TestWindowScheduleRedrawTaskConcurrent verifies that concurrent redraw
+// requests atomically claim a single deferred task. In particular, the
+// scheduled flag must already be visible when the task is published to the
+// display queue; otherwise DisplayRun can consume the task before the flag is
+// set and all later redraw requests will be dropped.
+func TestWindowScheduleRedrawTaskConcurrent(t *testing.T) {
+	const (
+		attempts = 100
+		workers  = 32
+	)
+
+	for attempt := 0; attempt < attempts; attempt++ {
+		d := &Display{}
+		w := &Window{Display: d}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(workers)
+		for i := 0; i < workers; i++ {
+			go func() {
+				defer wg.Done()
+				<-start
+				windowScheduleRedrawTask(w)
+			}()
+		}
+		close(start)
+		wg.Wait()
+
+		d.deferredMu.Lock()
+		queued := len(d.deferredListNew)
+		d.deferredMu.Unlock()
+
+		if queued != 1 {
+			t.Fatalf("attempt %d: queued redraw tasks = %d, want 1", attempt, queued)
+		}
+		if got := atomic.LoadInt32(&w.redrawTaskScheduled); got != 1 {
+			t.Fatalf("attempt %d: redrawTaskScheduled = %d, want 1", attempt, got)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

A live F4 Wayland session stopped repainting and appeared to ignore both keyboard and pointer input, although the process and Wayland socket were still healthy. A non-destructive debugger attach showed this impossible scheduler state:

- `redrawTaskScheduled == 1`
- deferred task queue empty
- no frame callback
- redraw and resize still needed

The race is in `windowScheduleRedrawTask`: it publishes the task with `displayDefer` before storing `redrawTaskScheduled = 1`. `DisplayRun` can dequeue and run the task in that gap; `Run` clears the flag, then the producer writes it back to 1. Every later redraw request is then coalesced into a task that no longer exists.

## Fix

Atomically claim `redrawTaskScheduled` with compare-and-swap before publishing the task. Clear the same field atomically when the task starts or redraw is inhibited. This also makes simultaneous scheduling calls coalesce without racing each other.

This is independent of the buffer-scale and pointer-event PRs: it only changes ownership of the existing redraw task slot.

## Verification

- `GOWORK=off go test -race -count=1 ./window/...`
- `GOWORK=off go test -count=20 ./window/...`
- `GOWORK=off go vet ./window`
- Added a 32-worker, 100-iteration contention regression test asserting exactly one queued task and a published scheduled flag.