### PR TITLE
fix(window/linux): keep client titlebar within configured geometry

### DIFF
--- a/window/window_linux.go
+++ b/window/window_linux.go
@@ -572,18 +572,24 @@ func (Window *Window) ToplevelConfigure(
 	}
 
 	if (width > 0) && (height > 0) {
-		/* The width / height params are for Window geometry,
-		 * but window_schedule_resize takes allocation. Add
-		 * on the shadow margin to get the difference. */
+		/* The configure dimensions are window-geometry dimensions, while
+		 * ScheduleResize takes the main-surface allocation.  A client titlebar
+		 * is a visible subsurface above that allocation, so remove it here;
+		 * windowGetGeometry adds the same extent back before committing the
+		 * xdg_surface geometry. */
 		var margin int32 = 0
+		contentHeight, ok := windowContentHeightForGeometry(Window, height)
+		if !ok {
+			return
+		}
 
-		Window.ScheduleResize(width+margin*2, height+margin*2)
+		Window.ScheduleResize(width+margin*2, contentHeight+margin*2)
 
 		// Update decoration sizes immediately during resize for smooth tracking
 		// Frame callbacks in UpdateSizeForResize prevent flicker while maintaining responsiveness
 		// This is called on every configure event to ensure decorations track window size in real-time
 		if Window.decoration != nil && !Window.fullscreen {
-			Window.decoration.UpdateSizeForResize(width, height)
+			Window.decoration.UpdateSizeForResize(width, contentHeight)
 		}
 	} else if (Window.savedAllocation.Width > 0) &&
 		(Window.savedAllocation.Height > 0) {
@@ -3188,6 +3194,35 @@ func windowGetAllocation(Window *Window, allocation *Rectangle) {
 //line 4445
 func windowGetGeometry(Window *Window, geometry *Rectangle) {
 	windowGetAllocation(Window, geometry)
+	if Window.decoration != nil {
+		// The title subsurface is positioned above the main surface. Window
+		// geometry must cover that visible titlebar as well as the content; the
+		// shadow is deliberately excluded because it is not part of the window.
+		geometry.Y -= TitleHeight
+		geometry.Height += TitleHeight
+	}
+}
+
+// windowUsesClientDecorations reports whether a configure includes the visible
+// title subsurface.  During the first configure decorations have not yet been
+// created, but they are requested and will be created by windowDoResize.
+func windowUsesClientDecorations(Window *Window) bool {
+	return Window != nil && !Window.fullscreen && Window.Display != nil &&
+		Window.Display.subcompositor != nil &&
+		(Window.decoration != nil || Window.decorationsRequested)
+}
+
+// windowContentHeightForGeometry converts a toplevel configure height in
+// xdg_surface window-geometry coordinates to the main-surface allocation
+// height.  It rejects a geometry too short to contain the visible titlebar.
+func windowContentHeightForGeometry(Window *Window, geometryHeight int32) (int32, bool) {
+	if !windowUsesClientDecorations(Window) {
+		return geometryHeight, true
+	}
+	if geometryHeight <= TitleHeight {
+		return 0, false
+	}
+	return geometryHeight - TitleHeight, true
 }
 
 //line 4458
@@ -3207,14 +3242,9 @@ func windowSyncGeometry(Window *Window) {
 		return
 	}
 
-	var yFix int32
-	if Window.decoration != nil {
-		yFix = TitleHeight
-	}
-
 	_ = Window.xdgSurface.SetWindowGeometry(
 		geometry.X,
-		geometry.Y-yFix,
+		geometry.Y,
 		geometry.Width,
 		geometry.Height)
 	Window.lastGeometry = geometry

--- a/window/window_linux_test.go
+++ b/window/window_linux_test.go
@@ -3,6 +3,8 @@
 package window
 
 import (
+	"github.com/neurlang/wayland/wl"
+
 	"sync"
 	"testing"
 	"time"
@@ -100,5 +102,73 @@ func TestDisplayRunWakesOnDefer(t *testing.T) {
 			// Not done yet; yield briefly before polling again.
 			time.Sleep(5 * time.Millisecond)
 		}
+	}
+}
+
+func TestWindowGeometryIncludesClientTitlebar(t *testing.T) {
+	window := &Window{
+		mainSurface: &surface{allocation: Rectangle{X: 3, Y: 5, Width: 1707, Height: 1021}},
+		decoration:  &WindowDecoration{},
+	}
+
+	var geometry Rectangle
+	windowGetGeometry(window, &geometry)
+
+	want := Rectangle{X: 3, Y: 5 - TitleHeight, Width: 1707, Height: 1021 + TitleHeight}
+	if geometry != want {
+		t.Fatalf("window geometry = %+v, want %+v", geometry, want)
+	}
+}
+
+func TestWindowGeometryExcludesNoUndecoratedSpace(t *testing.T) {
+	window := &Window{
+		mainSurface: &surface{allocation: Rectangle{X: 3, Y: 5, Width: 1707, Height: 1021}},
+	}
+
+	var geometry Rectangle
+	windowGetGeometry(window, &geometry)
+
+	want := Rectangle{X: 3, Y: 5, Width: 1707, Height: 1021}
+	if geometry != want {
+		t.Fatalf("window geometry = %+v, want %+v", geometry, want)
+	}
+}
+
+func TestWindowContentHeightForGeometry(t *testing.T) {
+	decorated := &Window{
+		Display:              &Display{subcompositor: &wl.Subcompositor{}},
+		decorationsRequested: true,
+	}
+
+	height, ok := windowContentHeightForGeometry(decorated, 1021)
+	if !ok || height != 1021-TitleHeight {
+		t.Fatalf("decorated content height = %d, %t; want %d, true", height, ok, 1021-TitleHeight)
+	}
+
+	decorated.decoration = &WindowDecoration{}
+	decorated.decorationsRequested = false
+	height, ok = windowContentHeightForGeometry(decorated, 1021)
+	if !ok || height != 1021-TitleHeight {
+		t.Fatalf("created decoration content height = %d, %t; want %d, true", height, ok, 1021-TitleHeight)
+	}
+
+	decorated.fullscreen = true
+	height, ok = windowContentHeightForGeometry(decorated, 1021)
+	if !ok || height != 1021 {
+		t.Fatalf("fullscreen content height = %d, %t; want 1021, true", height, ok)
+	}
+
+	undecorated := &Window{Display: &Display{subcompositor: &wl.Subcompositor{}}}
+	height, ok = windowContentHeightForGeometry(undecorated, 1021)
+	if !ok || height != 1021 {
+		t.Fatalf("undecorated content height = %d, %t; want 1021, true", height, ok)
+	}
+
+	_, ok = windowContentHeightForGeometry(&Window{
+		Display:              &Display{subcompositor: &wl.Subcompositor{}},
+		decorationsRequested: true,
+	}, TitleHeight)
+	if ok {
+		t.Fatal("titlebar-only geometry was accepted")
 	}
 }


### PR DESCRIPTION
## Problem

The library draws the client titlebar as a visible subsurface at `y = -TitleHeight` above the main content surface.

`xdg_toplevel.configure` dimensions are expressed in `xdg_surface` window-geometry coordinates. The previous implementation reported the titlebar in `set_window_geometry`, but then used the reported geometry height directly as the main-surface allocation on the next configure. That added the titlebar once per configure cycle. On KDE Wayland this made a maximized client taller than the compositor’s available area, so the bottom controls could fall behind the panel.

## Fix

- Treat configure height as visible window geometry.
- When client decorations are active, allocate `configureHeight - TitleHeight` to the main content surface.
- Continue reporting `y = -TitleHeight` and `height = contentHeight + TitleHeight` as the window geometry.
- Apply the same converted height when resizing the client decorations.
- Leave fullscreen and undecorated windows unchanged; neither has a visible client titlebar.
- Reject an impossible geometry no taller than the titlebar.

This makes the configure and geometry conversions exact inverses, without including the invisible shadow.

## Validation

```sh
GOWORK=off go test -count=30 ./window/...
GOWORK=off go test -race -count=20 ./window/...
GOWORK=off go vet ./window/...
```

All passed.