### PR TITLE
Send client-allocated ids to the compositor in allocation order

### DIFF
--- a/wl/context.go
+++ b/wl/context.go
@@ -108,7 +108,14 @@ func (ctx *Context) Register(proxy Proxy) {
 		SetUserData(c, &ctx)
 	}
 	ctx.objects[ctx.currentId] = proxy
-	ctx.markUnsent(ctx.currentId)
+	// The display is the one client-side proxy the compositor already
+	// knows: its id (1) is fixed by the protocol and no request ever
+	// carries it as a new_id. Tracking it as unsent would leave every
+	// later new id -- starting with wl_display.get_registry -- waiting
+	// for a write that never comes.
+	if _, isDisplay := proxy.(*Display); !isDisplay {
+		ctx.markUnsent(ctx.currentId)
+	}
 }
 
 // Unregister unregisters a proxy in the map of all Context objects (proxies)

--- a/wl/context.go
+++ b/wl/context.go
@@ -20,6 +20,61 @@ type Context struct {
 	currentId ProxyId
 	objects   map[ProxyId]Proxy
 	scms      []sys.SocketControlMessage
+
+	// The compositor requires client-allocated ids to arrive in the order
+	// they were allocated: libwayland's wl_map rejects a new id that is
+	// not the next free slot ("not a valid new object id"). Register hands
+	// out ids in order, but the request that carries an id to the wire is
+	// written later, by whichever goroutine created the proxy, so two
+	// goroutines can write their requests in the wrong order. sendMu
+	// serialises writes, unsent holds the ids Register has handed out
+	// that no request has carried yet, and sendCond lets a writer wait
+	// until every smaller id has gone.
+	sendMu   sync.Mutex
+	sendCond *sync.Cond
+	unsent   map[ProxyId]struct{}
+}
+
+// markUnsent records a freshly allocated client id as not yet on the wire.
+func (ctx *Context) markUnsent(id ProxyId) {
+	ctx.sendMu.Lock()
+	if ctx.unsent == nil {
+		ctx.unsent = make(map[ProxyId]struct{})
+		ctx.sendCond = sync.NewCond(&ctx.sendMu)
+	}
+	ctx.unsent[id] = struct{}{}
+	ctx.sendMu.Unlock()
+}
+
+// forgetUnsent drops an id from the unsent set and wakes any writer that
+// was waiting for it. Called once the id is on the wire, or when the proxy
+// is unregistered without ever being sent, so nobody waits for it forever.
+func (ctx *Context) forgetUnsent(id ProxyId) {
+	ctx.sendMu.Lock()
+	ctx.forgetUnsentLocked(id)
+	ctx.sendMu.Unlock()
+}
+
+func (ctx *Context) forgetUnsentLocked(id ProxyId) {
+	if ctx.unsent == nil {
+		return
+	}
+	if _, ok := ctx.unsent[id]; !ok {
+		return
+	}
+	delete(ctx.unsent, id)
+	ctx.sendCond.Broadcast()
+}
+
+// smallerUnsentLocked reports whether some id below id is still unsent.
+// Callers hold sendMu.
+func (ctx *Context) smallerUnsentLocked(id ProxyId) bool {
+	for other := range ctx.unsent {
+		if other < id {
+			return true
+		}
+	}
+	return false
 }
 
 func (ctx *Context) RegisterMapped(proxy Proxy, num uint32) {
@@ -53,6 +108,7 @@ func (ctx *Context) Register(proxy Proxy) {
 		SetUserData(c, &ctx)
 	}
 	ctx.objects[ctx.currentId] = proxy
+	ctx.markUnsent(ctx.currentId)
 }
 
 // Unregister unregisters a proxy in the map of all Context objects (proxies)
@@ -62,6 +118,7 @@ func (ctx *Context) Unregister(id ProxyId) {
 		delete(ctx.objects, id)
 	}
 	ctx.mu.Unlock()
+	ctx.forgetUnsent(id)
 }
 
 // LookupProxy looks up a specific proxy by it's Id in the map of all Context objects (proxies)

--- a/wl/context_display_test.go
+++ b/wl/context_display_test.go
@@ -1,0 +1,37 @@
+package wl
+
+import (
+	"syscall"
+	"testing"
+	"time"
+)
+
+// The display proxy gets id 1 from Register like any other proxy, but the
+// compositor already owns that id and no request ever carries it as a
+// new_id. If Register counted it as unsent, the first request that does
+// introduce an id -- wl_display.get_registry, id 2 -- would wait for id 1
+// forever, and a client would sit on a fresh connection without a window.
+func TestFirstRequestAfterConnectDoesNotWaitForDisplay(t *testing.T) {
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer syscall.Close(fds[0])
+	defer syscall.Close(fds[1])
+	ctx := &Context{sockFD: fds[0], objects: make(map[ProxyId]Proxy)}
+	display := NewDisplay(ctx)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := display.GetRegistry()
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wl_display.get_registry never reached the wire: it waits for id 1 (the display), which no request ever carries")
+	}
+}

--- a/wl/context_order_test.go
+++ b/wl/context_order_test.go
@@ -1,0 +1,58 @@
+package wl
+
+import (
+	"encoding/binary"
+	"io"
+	"os"
+	"sync"
+	"syscall"
+	"testing"
+)
+
+// Client-allocated ids must reach the compositor in allocation order:
+// libwayland's wl_map only accepts a new id that is the next free slot.
+// Here many goroutines each allocate a callback (wl_display.sync) and send
+// it, and the far end of a socketpair checks that the new ids it reads
+// never skip.
+func TestNewIdsReachTheWireInOrder(t *testing.T) {
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := &Context{sockFD: fds[0], objects: make(map[ProxyId]Proxy)}
+	display := NewDisplay(ctx) // id 1, never sent; the compositor owns it
+	ctx.forgetUnsent(display.Id())
+	reader := os.NewFile(uintptr(fds[1]), "compositor")
+	defer reader.Close()
+
+	const workers, perWorker = 8, 200
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				if _, err := display.Sync(); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		}()
+	}
+	go func() {
+		wg.Wait()
+		syscall.Close(fds[0])
+	}()
+
+	want := ProxyId(2)
+	hdr := make([]byte, 12) // object, size<<16|opcode, new_id
+	for n := 0; n < workers*perWorker; n++ {
+		if _, err := io.ReadFull(reader, hdr); err != nil {
+			t.Fatalf("message %d: %v", n, err)
+		}
+		if got := ProxyId(binary.LittleEndian.Uint32(hdr[8:])); got != want {
+			t.Fatalf("message %d: new id %d, want %d (ids reached the wire out of order)", n, got, want)
+		}
+		want++
+	}
+}

--- a/wl/context_order_test.go
+++ b/wl/context_order_test.go
@@ -21,7 +21,6 @@ func TestNewIdsReachTheWireInOrder(t *testing.T) {
 	}
 	ctx := &Context{sockFD: fds[0], objects: make(map[ProxyId]Proxy)}
 	display := NewDisplay(ctx) // id 1, never sent; the compositor owns it
-	ctx.forgetUnsent(display.Id())
 	reader := os.NewFile(uintptr(fds[1]), "compositor")
 	defer reader.Close()
 

--- a/wl/request.go
+++ b/wl/request.go
@@ -47,6 +47,32 @@ func (ctx *Context) SendRequest(proxy Proxy, opcode uint32, args ...interface{})
 		return err
 	}
 
+	// Ids this request introduces to the compositor. Usually none or one.
+	var newIds []ProxyId
+	ctx.sendMu.Lock()
+	for _, arg := range args {
+		p, ok := arg.(Proxy)
+		if !ok {
+			continue
+		}
+		if _, pending := ctx.unsent[p.Id()]; pending {
+			newIds = append(newIds, p.Id())
+		}
+	}
+	// A new id may only go out once every smaller id is on the wire; see
+	// the comment on Context.sendMu. Requests without a new id never wait.
+	for _, id := range newIds {
+		for ctx.smallerUnsentLocked(id) {
+			ctx.sendCond.Wait()
+		}
+	}
+	defer func() {
+		for _, id := range newIds {
+			ctx.forgetUnsentLocked(id)
+		}
+		ctx.sendMu.Unlock()
+	}()
+
 	if ctx.conn != nil {
 		return writeRequest(ctx.conn, req)
 	} else if ctx.sockFD != -1 {


### PR DESCRIPTION
libwayland on the compositor side only accepts a new client id that is the next free slot of its object map: a request carrying id N+1 before the request carrying id N has arrived is answered with "not a valid new object id (N+1)" and the connection is closed. Register allocates ids in order, but the request that carries an id to the wire is written later, by whichever goroutine created the proxy, and nothing kept the two orders in step. A client with more than one goroutine creating objects (a frame callback from the event loop, a wl_display.sync from a render thread) would therefore be disconnected now and then, with no error on its own side beyond a closed socket.

SendRequest now serialises writes and, when a request introduces a new id, waits until every smaller id handed out by Register is on the wire. Requests that carry no new id never wait. Unregister drops an id that was never sent, so no writer can wait for it forever. The test drives wl_display.sync from several goroutines through a socketpair and checks that the ids read at the far end never skip; it fails on the previous code.

Seen in the wild as KWin logging "not a valid new object id (153), message frame(n)" / "error in client communication" for a client with a renderer goroutine, every few actions.